### PR TITLE
initial commit with functionality fixes and improvements.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,7 +1,7 @@
-Compilation Unit Addon
+Unity Build Addon
 ======================
 
-Compilation Units is a technique used to speed up compilation of huge projects, by regrouping
+Unity builds is a technique used to speed up compilation of huge projects, by regrouping
 compilation unit files (basically the .cpp and .c files) into a few big ones. Basically, instead
 of compiling `foo.cpp` and `bar.cpp` you compile a single `foobaz.cpp` one which contains the
 following :
@@ -23,19 +23,19 @@ Clone this repository some place where Premake will be able to locate. Then
 in your project's Premake script, include the main file like this :
 
 ```lua
-require( "premake-compilationunit/compilationunit.lua" )
+require( "premake-unitybuild/unitybuild.lua" )
 ```
 
 Then in the projects where you want to enable support for compilation units :
 
 ```lua
-compilationunitenabled ( true )
+unitybuildenabled ( true )
 ```
 
 The final step is to invoke Premake using the `compilationunit` option:
 
 ```
-premake5 --compilationunit=8 <action>
+premake5 --unity-build <action>
 ```
 
 Here I tell the module to use 8 compilation unit files, for projects where it has
@@ -48,25 +48,34 @@ Most of the API commands of this addon are scoped to the current configuration,
 so unless specified otherwise, assume that the documented command only applies
 to the current configuration block.
 
-##### compilationunitenabled boolean
+##### unitybuildenabled boolean
 
 Enable or disable the compilation unit generation for the current filter. By default
 it's disabled.
 
-##### compilationunitsonly boolean
+##### unitybuildcount number
+
+Sets the number of unity build files to use for the project or configuration.  Vy
+default this is calculated so that there are at least 5 source files included in each
+unity build file such that there is a maximum of 8 unity build files total and a
+minimum of 1.  If this API is used, the given number of unity build files will be used
+explicitly unless there are fewer compilation units present in the project.  In most
+cases it is sufficient to allow the unity build files count to be auto-calculated.
+
+##### unitybuildfilesonly boolean
 
 If this option is set to `true` then the generated projects will not include the
 original files. By defaut this option is `false` to allow easily editing / browsing
 the original code in IDEs, but it can be set to `true` in case you don't need that
 (think automated build systems, etc.)
 
-##### compilationunitdir "path"
+##### unitybuilddir "path"
 
 The path where the compilation unit files will be generated. If not specified, the
 obj dir will be used. This is a per-project configuration. The addon takes care
 of handling the various configurations for you.
 
-##### compilationunitextensions table
+##### unitybuildextensions table
 
 By default the extension of the generated compilation units is `.c` for C files,
 and `.cpp` for C++ files. You can use a table to override these extensions. For
@@ -74,7 +83,7 @@ instance, if you want to enable compilation units on an Objective-C project:
 
 ```lua
 filter {}
-    compilationunitextensions {
+    unitybuildextensions {
         "C" = ".m",
         "C++" = ".mm"
     }

--- a/_manifest.lua
+++ b/_manifest.lua
@@ -1,5 +1,5 @@
 
 return {
 	"_preload.lua",
-	"compilationunit.lua"
+	"unitybuild.lua"
 }

--- a/_preload.lua
+++ b/_preload.lua
@@ -1,6 +1,6 @@
 
 --
--- avoid loading twice this file (see compilationunit.lua)
+-- avoid loading twice this file (see unitybuild.lua)
 --
 premake.extensions.compilationunit = true
 
@@ -9,43 +9,79 @@ premake.extensions.compilationunit = true
 -- register our custom option
 --
 newoption {
-	trigger = "compilationunit",
-	value = 8,
-	description = "Generate a project which uses N compilation units. Defaults to 8 units."
+	trigger = "unity-build",
+	description = "(Optional) Enable experimental unity builds on projects that have opted into it."
 }
 
+newoption {
+    trigger = "unity-log",
+    description = "(Optional) Enable some extra debug logging for the unity builds.  This should"..
+                  "only be used for debugging purposes when opting into unity builds for a project."
+}
+
+newoption {
+    trigger = "unity-log-filter",
+	value = "enabled",
+    description = "(Optional) Only show the log messages from the unity build for the given project"..
+				  "names.  Multiple project names may be given separated by commas (no blank spaces"..
+				  "between project names).  This may also be the special value 'enabled' to only show"..
+				  "the log messages for projects that have opted into unity builds."
+}
 
 --
 -- Enable the compilation units for a given configuration
 --
 premake.api.register {
-	name = "compilationunitenabled",
+	name = "unitybuildenabled",
 	scope = "config",
 	kind = "boolean"
 }
 
+--
+-- Set the preferred compilation unit file count for a project.
+--
+premake.api.register {
+	name = "unitybuildcount",
+	scope = "config",
+	kind = "number"
+}
 
 --
 -- Specify the path, relative to the current script or absolute, where the compilation
 -- unit files will be stored. If not specified, the project's obj dir will be used.
 --
 premake.api.register {
-	name = "compilationunitdir",
+	name = "unitybuilddir",
 	scope = "project",
 	kind = "path",
 	tokens = true
 }
 
+--
+-- Specifies a table of key/value pairs that will be added to each unity build file as
+-- a set of macros when they are generated.  These can be used to work around potential
+-- compilation issues due to multiple source files being compiled as one.  The macro
+-- `OMNI_USING_UNITY_BUILD` will always be added to each unity build file with the value
+-- `1`.  This macro name must not be included in this table.  This can be used for example
+-- to work around the common problem of Windows' `min()` and `max()` macros by adding
+-- the macro `NOMINMAX` and setting it to `1`.
+--
+premake.api.register {
+    name = "unitybuilddefines",
+    scope = "config",
+    kind = "table"
+}
+
 -- Compilation unit extensions.
 --
--- By default, either .c or .cpp extension are used for generated compilation units.
+-- By default, either .c or .cpp extension are used for generated unity build files.
 -- But you can override this extension per-language to let it handle objective-C or
 -- any other.
 --
 -- Here's an example allowing to mix C or C++ files with objective-C:
 -- 
 -- filter {}
--- 	compilationunitextensions {
+-- 	unitybuildextensions {
 --		"C" = ".m",	-- compilation unit extension for C files is .m
 --				-- (i.e. objective-C)
 --		"C++" = ".mm"	-- compilation unit extension for C++ files is .mm
@@ -53,7 +89,7 @@ premake.api.register {
 --	}
 --
 premake.api.register {
-	name = "compilationunitextensions",
+	name = "unitybuildextensions",
 	scope = "config",
 	kind = "table"
 }
@@ -65,7 +101,7 @@ premake.api.register {
 -- Default is to keep the original source files.
 --
 premake.api.register {
-	name = "compilationunitsonly",
+	name = "unitybuildfilesonly",
 	scope = "config",
 	kind = "boolean"
 }


### PR DESCRIPTION
- added debug logging support through the `--unity-log` and `--unity-log-filter` options.
- added support for specifying the unity build file count on a per-project or per-config level.
- added support for specifying custom defines for a project's unity build files.
- added a macro to each unity build file to allow its use to be detected in code.
- renamed the various APIs to use the name 'unitybuild' instead of 'compilationunit'.
- updated the readme doc to match the above changes.